### PR TITLE
Add GitHub Actions workflow to publish Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,23 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: Build the Docker image
+        run: docker build -t ${{ secrets.DOCKER_USERNAME }}/sdk:8.0 .
+
+      - name: Push the Docker image
+        run: docker push ${{ secrets.DOCKER_USERNAME }}/sdk:8.0

--- a/README.md
+++ b/README.md
@@ -11,3 +11,20 @@ ENV http_proxy=http://10.128.50.3:2568 \
     ftp_proxy=http://10.128.50.3:2568 \
     no_proxy=localhost,127.0.0.1,.uci.cu,10.0.0.0/8
 ```
+
+## Using the Published Docker Image
+
+The Docker image is published to Docker Hub and can be pulled and run using the following commands:
+
+```
+docker pull <your-docker-username>/sdk:latest
+docker run -it <your-docker-username>/sdk:latest
+```
+
+Replace `<your-docker-username>` with your actual Docker Hub username.
+
+You can also use the image in your `Dockerfile`:
+
+```
+FROM <your-docker-username>/sdk:latest
+```


### PR DESCRIPTION
Add GitHub Actions workflow to publish Docker image to Docker Hub.

* **Workflow Configuration**
  - Create `.github/workflows/docker-publish.yml` to define the workflow.
  - Trigger the workflow on push to the `main` branch.
  - Add steps to check out the repository, log in to Docker Hub, build the Docker image, and push it to Docker Hub.
  - Use Docker Hub credentials stored as secrets in the GitHub repository settings.

* **README Update**
  - Add a section with instructions on how to use the published Docker image.
  - Include the Docker Hub repository link and example commands to pull and run the Docker image.
  - Provide example usage in a `Dockerfile`.

